### PR TITLE
利用者名、ルーム名、チャットの入力制限を追加

### DIFF
--- a/frontend/src/component/ChatSpace.tsx
+++ b/frontend/src/component/ChatSpace.tsx
@@ -57,8 +57,9 @@ const ChatSpace = (props: Props) => {
   const isDisabled = () => {
     const messageMaxLength = 200;
     const messageRegex = new RegExp(/['\\]/);
+    const spaceRegex = new RegExp(/^\s+?$/);
 
-    if (message.length === 0 || message.length > messageMaxLength || messageRegex.test(message)) {
+    if (!message.length || message.length > messageMaxLength || messageRegex.test(message) || spaceRegex.test(message)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/ChatSpace.tsx
+++ b/frontend/src/component/ChatSpace.tsx
@@ -58,11 +58,7 @@ const ChatSpace = (props: Props) => {
     const messageMaxLength = 200;
     const messageRegex = new RegExp(/['\\]/);
 
-    if (message.length === 0) {
-      return true;
-    } else if (message.length > messageMaxLength) {
-      return true;
-    } else if (messageRegex.test(message)) {
+    if (message.length === 0 || message.length > messageMaxLength || messageRegex.test(message)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/ChatSpace.tsx
+++ b/frontend/src/component/ChatSpace.tsx
@@ -25,9 +25,10 @@ type SendMessage = {
   userName: string,
 }
 
-const socket = io('http://localhost:8000/');
+const url = 'http://localhost:8000';
+const socket = io(url);
 
-const ChatView = (props: Props) => {
+const ChatSpace = (props: Props) => {
   const [chatLog, setChatLog] = useState([]);
   const [message, setMessage] = useState('');
   const [messageList, setMessageList] = useState<SendMessage[]>([]);
@@ -38,7 +39,7 @@ const ChatView = (props: Props) => {
   }, [props.roomName]);
 
   useEffect(() => {
-    axios.get('/chat_log', {
+    axios.get(url + '/chat_log', {
       params: { roomId: props.roomId }
     })
       .then(response => {
@@ -53,13 +54,23 @@ const ChatView = (props: Props) => {
     });
   }, []);
 
-  const inputMessage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setMessage(event.target.value);
+  const isDisabled = () => {
+    const messageMaxLength = 200;
+    const messageRegex = new RegExp(/['\\]/);
+
+    if (message.length === 0) {
+      return true;
+    } else if (message.length > messageMaxLength) {
+      return true;
+    } else if (messageRegex.test(message)) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   const onClickSend = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
-    if (!message) { return };
 
     socket.emit('client_to_server',
       {
@@ -68,7 +79,7 @@ const ChatView = (props: Props) => {
       });
     setMessage('');
 
-    axios.post('/messages', {
+    axios.post(url + '/messages', {
       roomId: props.roomId,
       message,
       sender: props.userName,
@@ -99,12 +110,12 @@ const ChatView = (props: Props) => {
         <input
           value={message}
           placeholder='送信したい内容を入力して下さい'
-          onChange={inputMessage}
+          onChange={(event) => setMessage(event.target.value)}
         />
-        <button className='send-message-button' onClick={onClickSend}>送信</button>
+        <button className='send-message-button' onClick={onClickSend} disabled={isDisabled()}>送信</button>
       </div>
     </div>
   );
 }
 
-export default ChatView;
+export default ChatSpace;

--- a/frontend/src/component/ChatSpace.tsx
+++ b/frontend/src/component/ChatSpace.tsx
@@ -39,7 +39,7 @@ const ChatSpace = (props: Props) => {
   }, [props.roomName]);
 
   useEffect(() => {
-    axios.get(url + '/chat_log', {
+    axios.get(`${url}/chat_log`, {
       params: { roomId: props.roomId }
     })
       .then(response => {
@@ -76,7 +76,7 @@ const ChatSpace = (props: Props) => {
       });
     setMessage('');
 
-    axios.post(url + '/messages', {
+    axios.post(`${url}/messages`, {
       roomId: props.roomId,
       message,
       sender: props.userName,

--- a/frontend/src/component/CreateRoom.tsx
+++ b/frontend/src/component/CreateRoom.tsx
@@ -15,11 +15,7 @@ const CreateRoom = (props: Props) => {
     const roomNameMaxLength = 30;
     const roomNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
 
-    if (roomName.length === 0) {
-      return true;
-    } else if (roomName.length > roomNameMaxLength) {
-      return true;
-    } else if (roomNameRegex.test(roomName)) {
+    if (roomName.length === 0 || roomName.length > roomNameMaxLength || roomNameRegex.test(roomName)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/CreateRoom.tsx
+++ b/frontend/src/component/CreateRoom.tsx
@@ -9,30 +9,34 @@ type Props = {
 
 const CreateRoom = (props: Props) => {
   const [roomName, setRoomName] = useState('');
-  // const url = 'http://localhost:8000';
+  const url = 'http://localhost:8000';
 
-  const inputRoomName = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRoomName(event.target.value);
+  const isDisabled = () => {
+    const roomNameMaxLength = 30;
+    const roomNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
+
+    if (roomName.length === 0) {
+      return true;
+    } else if (roomName.length > roomNameMaxLength) {
+      return true;
+    } else if (roomNameRegex.test(roomName)) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   const onClickCreateRoom = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
-    const roomNameMaxLength = 30;
-    if (roomName.length === 0) {
-      alert('ルーム名を入力してください');
-    } else if (roomName.length > roomNameMaxLength) {
-      alert('文字数制限を超えています（30字以下）');
-      setRoomName('');
-    } else {
-      axios.post('/new_room', { roomName: roomName })
-        .then(response => {
-          axios.get('/room_info')
-            .then(response => {
-              props.setRoomInfo(response.data);
-            });
-        });
-      setRoomName('');
-    }
+
+    axios.post(url + '/new_room', { roomName: roomName })
+      .then(response => {
+        axios.get(url + '/room_info')
+          .then(response => {
+            props.setRoomInfo(response.data);
+          });
+      });
+    setRoomName('');
   }
 
   return (
@@ -41,8 +45,9 @@ const CreateRoom = (props: Props) => {
         <input
           value={roomName}
           placeholder='ルームを追加'
-          onChange={inputRoomName} />
-        <button className='create-button' onClick={onClickCreateRoom}>作成</button>
+          onChange={(event) => setRoomName(event.target.value)}
+        />
+        <button className='create-button' onClick={onClickCreateRoom} disabled={isDisabled()}>作成</button>
       </div>
     </div>
   )

--- a/frontend/src/component/CreateRoom.tsx
+++ b/frontend/src/component/CreateRoom.tsx
@@ -26,9 +26,9 @@ const CreateRoom = (props: Props) => {
   const onClickCreateRoom = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
 
-    axios.post(url + '/new_room', { roomName: roomName })
-      .then(response => {
-        axios.get(url + '/room_info')
+    axios.post(`${url}/new_room`, { roomName: roomName })
+      .then(() => {
+        axios.get(`${url}/room_info`)
           .then(response => {
             props.setRoomInfo(response.data);
           });

--- a/frontend/src/component/CreateRoom.tsx
+++ b/frontend/src/component/CreateRoom.tsx
@@ -13,9 +13,10 @@ const CreateRoom = (props: Props) => {
 
   const isDisabled = () => {
     const roomNameMaxLength = 30;
-    const roomNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
+    const roomNameRegex = new RegExp(/[!-/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・]/);
+    const spaceRegex = new RegExp(/^\s+?$/);
 
-    if (roomName.length === 0 || roomName.length > roomNameMaxLength || roomNameRegex.test(roomName)) {
+    if (!roomName.length || roomName.length > roomNameMaxLength || roomNameRegex.test(roomName) || spaceRegex.test(roomName)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/RegisterUserName.tsx
+++ b/frontend/src/component/RegisterUserName.tsx
@@ -11,9 +11,10 @@ const RegisterUserName = () => {
 
   const isDisabled = () => {
     const userNameMaxLength = 20;
-    const userNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
+    const userNameRegex = new RegExp(/[!-/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・]/);
+    const spaceRegex = new RegExp(/^\s+?$/);
 
-    if (userName.length === 0 || userName.length > userNameMaxLength || userNameRegex.test(userName)) {
+    if (!userName.length || userName.length > userNameMaxLength || userNameRegex.test(userName) || spaceRegex.test(userName)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/RegisterUserName.tsx
+++ b/frontend/src/component/RegisterUserName.tsx
@@ -13,11 +13,7 @@ const RegisterUserName = () => {
     const userNameMaxLength = 20;
     const userNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
 
-    if (userName.length === 0) {
-      return true;
-    } else if (userName.length > userNameMaxLength) {
-      return true;
-    } else if (userNameRegex.test(userName)) {
+    if (userName.length === 0 || userName.length > userNameMaxLength || userNameRegex.test(userName)) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/RegisterUserName.tsx
+++ b/frontend/src/component/RegisterUserName.tsx
@@ -9,22 +9,48 @@ const RegisterUserName = () => {
   const [switchRoomList, setSwitchRoomList] = useState(false);
   const [userName, setUserName] = useState('');
 
-  const inputUserName = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUserName(event.target.value);
-  }
+  const isDisabled = () => {
+    const AtoZ = '\\w'
+    const hiragana = '\\p{scx=Hiragana}'
+    const katakanaZen = '\\p{scx=Katakana}'
+    const katakanaHan = 'ｦ-ﾟ'
+    const kanji = '\\p{scx=Han}'
+    const mixRegex = (...regex: string[][]) => new RegExp('^[' + regex.join('') + ']+$', 'u')
 
-  const userNameCheck = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    event.preventDefault();
+    if (mixRegex([AtoZ, hiragana, katakanaZen, katakanaHan, kanji]).test(userName)) {
+      console.log(userName, ' は正しい入力です');
+    } else {
+      console.log(userName, ' は禁則文字です');
+    }
+
     const userNameMaxLength = 20;
     if (userName.length === 0) {
-      alert('名前を入力してください');
+      return true;
     } else if (userName.length > userNameMaxLength) {
-      alert('文字数制限を超えています(20字以下)');
-      setUserName('');
+      return true;
+    } else if (!mixRegex([AtoZ, hiragana, katakanaZen, katakanaHan, kanji]).test(userName)) {
+      return true;
     } else {
-      setSwitchRoomList(true);
+      return false;
     }
   }
+
+  // const inputUserName = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   setUserName(event.target.value);
+  // }
+
+  // const userNameCheck = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  //   event.preventDefault();
+  //   const userNameMaxLength = 20;
+  //   if (userName.length === 0) {
+  //     alert('名前を入力してください');
+  //   } else if (userName.length > userNameMaxLength) {
+  //     alert('文字数制限を超えています(20字以下)');
+  //     setUserName('');
+  //   } else {
+  //     setSwitchRoomList(true);
+  //   }
+  // }
 
   return (
     <div>
@@ -32,13 +58,13 @@ const RegisterUserName = () => {
         <div>
           <div className='welcome-text'>ようこそ</div>
           <div className='input-user-name'>
-              <input
-                type='text'
-                value={userName}
-                onChange={inputUserName}
-                placeholder='名前を入力してください'
-              />
-              <button className='register-button' onClick={userNameCheck}>登録</button>
+            <input
+              type='text'
+              value={userName}
+              onChange={(event) => setUserName(event.target.value)}
+              placeholder='名前を入力してください'
+            />
+            <button className='register-button' onClick={() => setSwitchRoomList(true)} disabled={isDisabled()}>登録</button>
           </div>
         </div>
       }

--- a/frontend/src/component/RegisterUserName.tsx
+++ b/frontend/src/component/RegisterUserName.tsx
@@ -10,47 +10,19 @@ const RegisterUserName = () => {
   const [userName, setUserName] = useState('');
 
   const isDisabled = () => {
-    const AtoZ = '\\w'
-    const hiragana = '\\p{scx=Hiragana}'
-    const katakanaZen = '\\p{scx=Katakana}'
-    const katakanaHan = 'ｦ-ﾟ'
-    const kanji = '\\p{scx=Han}'
-    const mixRegex = (...regex: string[][]) => new RegExp('^[' + regex.join('') + ']+$', 'u')
-
-    if (mixRegex([AtoZ, hiragana, katakanaZen, katakanaHan, kanji]).test(userName)) {
-      console.log(userName, ' は正しい入力です');
-    } else {
-      console.log(userName, ' は禁則文字です');
-    }
-
     const userNameMaxLength = 20;
+    const userNameRegex = new RegExp(/[ -/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・　]/);
+
     if (userName.length === 0) {
       return true;
     } else if (userName.length > userNameMaxLength) {
       return true;
-    } else if (!mixRegex([AtoZ, hiragana, katakanaZen, katakanaHan, kanji]).test(userName)) {
+    } else if (userNameRegex.test(userName)) {
       return true;
     } else {
       return false;
     }
   }
-
-  // const inputUserName = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   setUserName(event.target.value);
-  // }
-
-  // const userNameCheck = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-  //   event.preventDefault();
-  //   const userNameMaxLength = 20;
-  //   if (userName.length === 0) {
-  //     alert('名前を入力してください');
-  //   } else if (userName.length > userNameMaxLength) {
-  //     alert('文字数制限を超えています(20字以下)');
-  //     setUserName('');
-  //   } else {
-  //     setSwitchRoomList(true);
-  //   }
-  // }
 
   return (
     <div>
@@ -69,7 +41,8 @@ const RegisterUserName = () => {
         </div>
       }
       {switchRoomList && <RoomList userName={userName} />}
-    </div >
+    </div>
   );
 };
+
 export default RegisterUserName

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -30,9 +30,6 @@ const RoomList = (props: Props) => {
       .then((response) => {
         setRoomData(response.data);
       })
-      .catch((error) => {
-        console.log('error:' error);
-      })
   }, []);
 
   const onClickSwitchCreateRoom = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -49,14 +46,14 @@ const RoomList = (props: Props) => {
 
   const onClickRoomName = (index: number) => {
     setRoomId(index);
-    setRoomName(roomData[index - 1]['room_name']);
+    setRoomName(roomData[index-1]['room_name']);
 
     const initialText = document.getElementById('initialText');
     const selectedRoomName = document.getElementsByClassName('room-name')[index - 1].textContent;
     initialText!.textContent = selectedRoomName;
 
     if (switchCreateRoom === true) {
-      setSwitchCreateRoom(false)
+      setSwitchCreateRoom(false);
     }
     setSwitchChatSpace(true);
   }

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -26,7 +26,7 @@ const RoomList = (props: Props) => {
   const url = 'http://localhost:8000';
 
   useEffect(() => {
-    axios.get(url + '/room_info')
+    axios.get(`${url}/room_info`)
       .then((response) => {
         setRoomData(response.data);
       })
@@ -46,7 +46,7 @@ const RoomList = (props: Props) => {
 
   const onClickRoomName = (index: number) => {
     setRoomId(index);
-    setRoomName(roomData[index-1]['room_name']);
+    setRoomName(roomData[index - 1]['room_name']);
 
     const initialText = document.getElementById('initialText');
     const selectedRoomName = document.getElementsByClassName('room-name')[index - 1].textContent;

--- a/frontend/src/css/button.css
+++ b/frontend/src/css/button.css
@@ -1,24 +1,26 @@
 .register-button {
   width: 20%;
   padding: 1vmax;
-  border: 1px solid #27acd9;
+  border: 1px solid #55c4e9;
   border-radius: 5px;
-  color: #27acd9;
+  color: white;
   font-size: 1rem;
   line-height: 1.5;
   transition: 0.5s;
+  background-color: #55c4e9;
 }
 
 .create-room-button {
   width: 97%;
   margin: 1.5%;
   padding: 0.5rem;
-  border: 1px solid #27acd9;
+  border: 1px solid #55c4e9;
   border-radius: 5px;
-  color: #27acd9;
+  color: white;
   font-size: 1rem;
   line-height: 1.5;
   transition: 0.5s;
+  background-color: #55c4e9;
 }
 
 .create-button {
@@ -26,19 +28,27 @@
   margin-left: 1%;
   margin-bottom: 10%;
   padding: 0.5vmax;
-  border: 1px solid #27acd9;
+  border: 1px solid #55c4e9;
   border-radius: 5px;
-  color: #27acd9;
+  color: white;
   font-size: 1rem;
   line-height: 1.5;
   transition: 0.5s;
+  background-color: #55c4e9;
 }
 
 .register-button:hover,
 .create-room-button:hover,
 .create-button:hover {
-  color: whitesmoke;
-  background-color: #27acd9;
+  border-color: #1e8db1;
+  background-color: #1e8db1;
+}
+
+.register-button:disabled,
+.create-button:disabled {
+  color: white;
+  border-color: #c1eaf8;
+  background-color: #c1eaf8;
 }
 
 .send-message-button {
@@ -54,7 +64,11 @@
 }
 
 .send-message-button:hover {
-  color: whitesmoke;
-  border: 1px solid #87CEFA;
-  background-color: #87CEFA;
+  border-color: #0034d1;
+  background-color: #0034d1;
+}
+
+.send-message-button:disabled{
+  border-color: #99b3ff;
+  background-color: #99b3ff;
 }

--- a/frontend/src/css/list.css
+++ b/frontend/src/css/list.css
@@ -25,6 +25,7 @@
   background-color: #DDDDDD;
   cursor: pointer;
   transition: 0.3s;
+  word-break: break-all;
 }
 
 .room-name-list li:hover {
@@ -54,6 +55,7 @@
   line-height: 1.5;
   list-style: none;
   background-color: #D9E5FF;
+  word-break: break-all;
 }
 
 .others-chat-list {
@@ -67,4 +69,5 @@
   line-height: 1.5;
   list-style: none;
   background-color: white;
+  word-break: break-all;
 }

--- a/frontend/src/css/text.css
+++ b/frontend/src/css/text.css
@@ -1,4 +1,4 @@
-.welcome-text{
+.welcome-text {
   width: 70%;
   margin: 10% auto 0;
   text-align: center;
@@ -8,7 +8,6 @@
 
 .room-name-text {
   width: 95%;
-  height: 5%;
   margin: 0 auto;
   padding: 0.5%;
   border-bottom: 2px solid #DDDDDD;


### PR DESCRIPTION
### **レビュー希望納期**
2023/03/07

### **Issue**
#19 制限によってボタンの活性/非活性を切り替える
#25 チャットの文字数制限
#30#37 入力禁止文字の制限（禁則文字、絵文字等）

### **対応内容**
- 利用者名とルーム名は、半角/全角英数字、ひらがな、カタカナ、漢字以外の入力を制限するようにした
- チャットの入力は、「'」「\」の入力のみを制限し、200文字の入力上限を加えた
- 制限した文字種を入力、もしくは上限を超える文字数の入力があった場合にボタンを非活性に切り替えるようにした
- ボタンデザインで、非活性状態は薄く、活性状態でマウスホバーした場合は濃く表示するようにした

### **動作確認**
利用者名とルーム名には、半角/全角英数字、ひらがな、カタカナ、漢字を入力するとボタンが活性状態になる
半角/全角英数字、ひらがな、カタカナ、漢字以外の記号などを入力した場合はボタンが非活性状態になる
チャットは「'」「\」を入力した場合は、送信ボタンが非活性になる

### **レビューポイント**
なし