### PR TITLE
右クリックメニューを実装

### DIFF
--- a/frontend/src/component/ChatSpace.tsx
+++ b/frontend/src/component/ChatSpace.tsx
@@ -100,7 +100,7 @@ const ChatSpace = (props: Props) => {
             </div>
           ))}
         </ul>
-      </div >
+      </div>
 
       <div className='input-message'>
         <p className='user-name-text'>{props.userName}</p>

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -4,7 +4,7 @@ import CreateRoom from './CreateRoom';
 import ChatView from './ChatSpace';
 import '../css/block-room-list.css';
 import '../css/button.css';
-import '../css/contextmenu.css';
+import '../css/context-menu.css';
 import '../css/list.css';
 import '../css/text-box.css';
 import '../css/text.css';
@@ -62,16 +62,16 @@ const RoomList = (props: Props) => {
   const viewContextMenu = (event: React.MouseEvent) => {
     event.preventDefault();
 
-    const contextmenu = document.getElementById('contextMenu');
-    contextmenu!.style.left = event.pageX + 'px';
-    contextmenu!.style.top = event.pageY + 'px';
-    contextmenu!.style.display = 'block';
+    const contextMenu = document.getElementById('contextMenu');
+    contextMenu!.style.left = event.pageX + 'px';
+    contextMenu!.style.top = event.pageY + 'px';
+    contextMenu!.style.display = 'block';
 
     const roomNameList = document.getElementById('roomNameList');
     roomNameList!.style.pointerEvents = 'none';
 
     document.body.addEventListener('click', () => {
-      contextmenu!.style.display = 'none';
+      contextMenu!.style.display = 'none';
       roomNameList!.style.pointerEvents = 'auto';
     })
   }

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import CreateRoom from './CreateRoom';
-import ChatSpace from './ChatSpace';
-import EditRoom from './EditRoom';
+import ChatView from './ChatSpace';
 import '../css/block-room-list.css';
 import '../css/button.css';
 import '../css/contextmenu.css';
@@ -60,9 +59,8 @@ const RoomList = (props: Props) => {
     setSwitchChatSpace(true);
   }
 
-  const viewContextMenu = (event: React.MouseEvent, index: number) => {
+  const viewContextMenu = (event: React.MouseEvent) => {
     event.preventDefault();
-    setRoomId(index);
 
     const contextmenu = document.getElementById('contextMenu');
     contextmenu!.style.left = event.pageX + 'px';
@@ -79,7 +77,7 @@ const RoomList = (props: Props) => {
   }
 
   return (
-    <div className='whole'>
+    <div className='whole' >
       <div className='room-list-space'>
         <div className='room-name-list' id='roomNameList'>
           <ul>
@@ -87,7 +85,7 @@ const RoomList = (props: Props) => {
               <li
                 className='room-name'
                 onClick={() => onClickRoomName(room.room_id)}
-                onContextMenu={(event) => viewContextMenu(event, room.room_id)}
+                onContextMenu={viewContextMenu}
                 key={room.room_id}
               >{room.room_name}</li>
             ))}
@@ -99,12 +97,12 @@ const RoomList = (props: Props) => {
       <div className='work-space'>
         <div id='initialText' className='room-name-text'>ルームを選択してください</div>
         {switchCreateRoom && <CreateRoom setRoomInfo={setRoomData} />}
-        {switchChatSpace && <ChatSpace userName={props.userName} roomId={roomId} roomName={roomName} />}
+        {switchChatSpace && <ChatView userName={props.userName} roomId={roomId} roomName={roomName} />}
       </div>
 
       <div className='context-menu' id='contextMenu'>
         <ul>
-          <li id='editRoom' onClick={() => EditRoom(roomId)}>ルームを編集</li>
+          <li>ルームを編集</li>
           <li>ルームを削除</li>
         </ul>
       </div>

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -77,7 +77,7 @@ const RoomList = (props: Props) => {
   }
 
   return (
-    <div className='whole' >
+    <div className='whole'>
       <div className='room-list-space'>
         <div className='room-name-list' id='roomNameList'>
           <ul>

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -4,6 +4,7 @@ import CreateRoom from './CreateRoom';
 import ChatView from './ChatSpace';
 import '../css/block-room-list.css';
 import '../css/button.css';
+import '../css/contextmenu.css';
 import '../css/list.css';
 import '../css/text-box.css';
 import '../css/text.css';
@@ -58,13 +59,35 @@ const RoomList = (props: Props) => {
     setSwitchChatSpace(true);
   }
 
+  const viewContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+
+    const contextmenu = document.getElementById('contextMenu');
+    contextmenu!.style.left = event.pageX + 'px';
+    contextmenu!.style.top = event.pageY + 'px';
+    contextmenu!.style.display = 'block';
+
+    const roomNameList = document.getElementById('roomNameList');
+    roomNameList!.style.pointerEvents = 'none';
+
+    document.body.addEventListener('click', () => {
+      contextmenu!.style.display = 'none';
+      roomNameList!.style.pointerEvents = 'auto';
+    })
+  }
+
   return (
-    <div className='whole'>
+    <div className='whole' >
       <div className='room-list-space'>
-        <div className='room-name-list'>
+        <div className='room-name-list' id='roomNameList'>
           <ul>
             {roomData.map((room: Room) => (
-              <li className='room-name' onClick={() => onClickRoomName(room.room_id)} key={room.room_id}>{room.room_name}</li>
+              <li
+                className='room-name'
+                onClick={() => onClickRoomName(room.room_id)}
+                onContextMenu={viewContextMenu}
+                key={room.room_id}
+              >{room.room_name}</li>
             ))}
           </ul>
         </div>
@@ -75,6 +98,13 @@ const RoomList = (props: Props) => {
         <div id='initialText' className='room-name-text'>ルームを選択してください</div>
         {switchCreateRoom && <CreateRoom setRoomInfo={setRoomData} />}
         {switchChatSpace && <ChatView userName={props.userName} roomId={roomId} roomName={roomName} />}
+      </div>
+
+      <div className='context-menu' id='contextMenu'>
+        <ul>
+          <li>ルームを編集</li>
+          <li>ルームを削除</li>
+        </ul>
       </div>
     </div>
   );

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import CreateRoom from './CreateRoom';
-import ChatView from './ChatSpace';
+import ChatSpace from './ChatSpace';
+import EditRoom from './EditRoom';
 import '../css/block-room-list.css';
 import '../css/button.css';
 import '../css/contextmenu.css';
@@ -59,8 +60,9 @@ const RoomList = (props: Props) => {
     setSwitchChatSpace(true);
   }
 
-  const viewContextMenu = (event: React.MouseEvent) => {
+  const viewContextMenu = (event: React.MouseEvent, index: number) => {
     event.preventDefault();
+    setRoomId(index);
 
     const contextmenu = document.getElementById('contextMenu');
     contextmenu!.style.left = event.pageX + 'px';
@@ -77,7 +79,7 @@ const RoomList = (props: Props) => {
   }
 
   return (
-    <div className='whole' >
+    <div className='whole'>
       <div className='room-list-space'>
         <div className='room-name-list' id='roomNameList'>
           <ul>
@@ -85,7 +87,7 @@ const RoomList = (props: Props) => {
               <li
                 className='room-name'
                 onClick={() => onClickRoomName(room.room_id)}
-                onContextMenu={viewContextMenu}
+                onContextMenu={(event) => viewContextMenu(event, room.room_id)}
                 key={room.room_id}
               >{room.room_name}</li>
             ))}
@@ -97,12 +99,12 @@ const RoomList = (props: Props) => {
       <div className='work-space'>
         <div id='initialText' className='room-name-text'>ルームを選択してください</div>
         {switchCreateRoom && <CreateRoom setRoomInfo={setRoomData} />}
-        {switchChatSpace && <ChatView userName={props.userName} roomId={roomId} roomName={roomName} />}
+        {switchChatSpace && <ChatSpace userName={props.userName} roomId={roomId} roomName={roomName} />}
       </div>
 
       <div className='context-menu' id='contextMenu'>
         <ul>
-          <li>ルームを編集</li>
+          <li id='editRoom' onClick={() => EditRoom(roomId)}>ルームを編集</li>
           <li>ルームを削除</li>
         </ul>
       </div>

--- a/frontend/src/css/context-menu.css
+++ b/frontend/src/css/context-menu.css
@@ -1,0 +1,21 @@
+.context-menu {
+  position: fixed;
+  width: 200px;
+  padding: 5px 0;
+  left: 0px;
+  top: 0px;
+  display: none;
+  border: 1px solid #000;
+  border-radius: 5px;
+  background-color: #fff;
+}
+
+.context-menu li {
+  padding-left: 10%;
+  list-style: none;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background-color: antiquewhite;
+}

--- a/frontend/src/css/contextmenu.css
+++ b/frontend/src/css/contextmenu.css
@@ -1,0 +1,21 @@
+.context-menu {
+  position: fixed;
+  width: 200px;
+  padding: 5px 0;
+  left: 0px;
+  top: 0px;
+  display: none;
+  border: 1px solid #000;
+  border-radius: 5px;
+  background-color: #fff;
+}
+
+.context-menu li {
+  padding-left: 10%;
+  list-style: none;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background-color: antiquewhite;
+}


### PR DESCRIPTION
### **レビュー希望納期**
2023/03/10

### **Issue**
ルームに対して右クリックメニューを表示する

### **対応内容**
- ルーム一覧にあるルームを右クリックしたときに、独自の右クリックメニューを表示するようにした
  - メニューの内容は「ルームを編集」と「ルームを削除」の2項目あるが、機能自体は未実装
- 仮で右クリックメニューのデザインを実装した
- 追加：右クリックメニューが表示されている間は、ルームを押せない状態にした

### **動作確認**
ルーム一覧にあるルームを右クリックしたときに、独自の右クリックメニューを表示される
画面上（どこでも良い）で左クリックした際に表示が消える
右クリックメニューが表示されている間は、ルームを押してもルームが切り替わらない（右クリックメニューが消えるだけ）

### **レビューポイント**
なし

### **備考**
メッセージの右クリックメニューは、ルームの方が完了次第実装する
（メッセージの編集・削除機能を実装する際に同時に実装する）

[93d659a](https://github.com/RuiFujita/web_chat_app/pull/2/commits/93d659ad9d85ca6409f95c8df6d11759c03ae735)