### PR TITLE
ルーム名を編集する機能の実装

### DIFF
--- a/backend/database.ts
+++ b/backend/database.ts
@@ -40,6 +40,18 @@ app.post('/new_room', (request, response) => {
   });
 })
 
+app.post('/edit_room', (request, response) => {
+  response.set({ 'Access-Control-Allow-Origin': '*' })
+  connection.connect();
+
+  const roomName = request.body.roomName;
+  const roomId = request.body.roomId;
+  connection.query(`UPDATE room_info SET room_name='${roomName}' WHERE (room_id=${roomId})`, function (error: any, results: []) {
+    if (error) throw error;
+    response.status(200).send(results);
+  });
+})
+
 app.get('/chat_log', (request, response) => {
   response.set({ 'Access-Control-Allow-Origin': '*' })
   connection.connect();

--- a/frontend/src/component/EditRoom.tsx
+++ b/frontend/src/component/EditRoom.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import axios from 'axios';
+import '../css/button.css';
+import '../css/modal-window.css';
+
+type Props = {
+  roomId: number,
+  roomName: string,
+  setViewEditWindow: Function,
+  setRoomInfo: Function
+}
+
+const EditRoom = (props: Props) => {
+  const [editedRoomName, setEditedRoomName] = useState(props.roomName);
+  const url = 'http://localhost:8000';
+
+  const isDisabled = () => {
+    const roomNameMaxLength = 30;
+    const roomNameRegex = new RegExp(/[!-/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・]/);
+    const spaceRegex = new RegExp(/^\s+?$/);
+
+    if (!editedRoomName.length || editedRoomName.length > roomNameMaxLength || roomNameRegex.test(editedRoomName) || spaceRegex.test(editedRoomName)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  const onClickEditRoom = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.preventDefault();
+
+    axios.post(`${url}/edit_room`, {
+      roomName: editedRoomName,
+      roomId: props.roomId
+    })
+      .then(() => {
+        axios.get(`${url}/room_info`)
+          .then(response => {
+            props.setRoomInfo(response.data);
+          });
+      });
+    props.setViewEditWindow(false);
+  }
+
+  return (
+    <div className='modal-back'>
+      <div className='modal-content'>
+        <button className='close-button' onClick={() => { props.setViewEditWindow(false) }}>×</button>
+        <div className='edit-room-name-text'>ルーム名を変更します</div>
+        <div className='input-edited-room-name'>ルーム名
+          <input
+            value={editedRoomName}
+            onChange={(event) => setEditedRoomName(event.target.value)}
+          />
+        </div>
+        <div className='modal-content-button'>
+          <button className='cancel-button' onClick={() => { props.setViewEditWindow(false) }}>キャンセル</button>
+          <button className='edit-button' onClick={onClickEditRoom} disabled={isDisabled()}>変更</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default EditRoom;

--- a/frontend/src/component/EditRoom.tsx
+++ b/frontend/src/component/EditRoom.tsx
@@ -19,7 +19,11 @@ const EditRoom = (props: Props) => {
     const roomNameRegex = new RegExp(/[!-/:-@[-`{-~！-／：-＠［-｀｛-～、-〜”’・]/);
     const spaceRegex = new RegExp(/^\s+?$/);
 
-    if (!editedRoomName.length || editedRoomName.length > roomNameMaxLength || roomNameRegex.test(editedRoomName) || spaceRegex.test(editedRoomName)) {
+    if (!editedRoomName.length
+      || editedRoomName.length > roomNameMaxLength
+      || roomNameRegex.test(editedRoomName)
+      || spaceRegex.test(editedRoomName)
+      || editedRoomName === props.roomName) {
       return true;
     } else {
       return false;

--- a/frontend/src/component/RegisterUserName.tsx
+++ b/frontend/src/component/RegisterUserName.tsx
@@ -37,7 +37,7 @@ const RegisterUserName = () => {
           </div>
         </div>
       }
-      {switchRoomList && <RoomList userName={userName} />}
+      {switchRoomList && <RoomList userName={userName}/>}
     </div>
   );
 };

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -22,6 +22,7 @@ type Room = {
 const RoomList = (props: Props) => {
   const [roomData, setRoomData] = useState([]);
   const [roomId, setRoomId] = useState(0);
+  const [contextMenuRoomId, setContextMenuRoomId] = useState(0);
   const [roomName, setRoomName] = useState('');
   const [switchCreateRoom, setSwitchCreateRoom] = useState(false);
   const [switchChatSpace, setSwitchChatSpace] = useState(false);
@@ -62,7 +63,7 @@ const RoomList = (props: Props) => {
 
   const viewContextMenu = (event: React.MouseEvent, index: number) => {
     event.preventDefault();
-    setRoomId(index);
+    setContextMenuRoomId(index);
     setRoomName(roomData[index - 1]['room_name']);
 
     const contextmenu = document.getElementById('contextMenu');
@@ -116,7 +117,7 @@ const RoomList = (props: Props) => {
       </div>
       {viewEditWindow &&
         <EditRoom
-          roomId={roomId}
+          roomId={contextMenuRoomId}
           roomName={roomName}
           setViewEditWindow={setViewEditWindow}
           setRoomInfo={setRoomData}

--- a/frontend/src/component/RoomList.tsx
+++ b/frontend/src/component/RoomList.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import CreateRoom from './CreateRoom';
-import ChatView from './ChatSpace';
+import ChatSpace from './ChatSpace';
+import EditRoom from './EditRoom';
 import '../css/block-room-list.css';
 import '../css/button.css';
+import '../css/context-menu.css';
 import '../css/list.css';
 import '../css/text-box.css';
 import '../css/text.css';
@@ -23,6 +25,7 @@ const RoomList = (props: Props) => {
   const [roomName, setRoomName] = useState('');
   const [switchCreateRoom, setSwitchCreateRoom] = useState(false);
   const [switchChatSpace, setSwitchChatSpace] = useState(false);
+  const [viewEditWindow, setViewEditWindow] = useState(false);
   const url = 'http://localhost:8000';
 
   useEffect(() => {
@@ -35,13 +38,12 @@ const RoomList = (props: Props) => {
   const onClickSwitchCreateRoom = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
 
+    const initialText = document.getElementById('initialText');
+    initialText!.textContent = 'ルームを作成します';
     if (switchChatSpace) {
       setSwitchChatSpace(false);
     }
     setSwitchCreateRoom(true);
-
-    const initialText = document.getElementById('initialText');
-    initialText!.textContent = 'ルームを作成します';
   }
 
   const onClickRoomName = (index: number) => {
@@ -58,13 +60,37 @@ const RoomList = (props: Props) => {
     setSwitchChatSpace(true);
   }
 
+  const viewContextMenu = (event: React.MouseEvent, index: number) => {
+    event.preventDefault();
+    setRoomId(index);
+    setRoomName(roomData[index - 1]['room_name']);
+
+    const contextmenu = document.getElementById('contextMenu');
+    contextmenu!.style.left = event.pageX + 'px';
+    contextmenu!.style.top = event.pageY + 'px';
+    contextmenu!.style.display = 'block';
+
+    const roomNameList = document.getElementById('roomNameList');
+    roomNameList!.style.pointerEvents = 'none';
+
+    document.body.addEventListener('click', () => {
+      contextmenu!.style.display = 'none';
+      roomNameList!.style.pointerEvents = 'auto';
+    })
+  }
+
   return (
     <div className='whole'>
       <div className='room-list-space'>
-        <div className='room-name-list'>
+        <div className='room-name-list' id='roomNameList'>
           <ul>
             {roomData.map((room: Room) => (
-              <li className='room-name' onClick={() => onClickRoomName(room.room_id)} key={room.room_id}>{room.room_name}</li>
+              <li
+                className='room-name'
+                onClick={() => onClickRoomName(room.room_id)}
+                onContextMenu={(event) => viewContextMenu(event, room.room_id)}
+                key={room.room_id}
+              >{room.room_name}</li>
             ))}
           </ul>
         </div>
@@ -74,8 +100,27 @@ const RoomList = (props: Props) => {
       <div className='work-space'>
         <div id='initialText' className='room-name-text'>ルームを選択してください</div>
         {switchCreateRoom && <CreateRoom setRoomInfo={setRoomData} />}
-        {switchChatSpace && <ChatView userName={props.userName} roomId={roomId} roomName={roomName} />}
+        {switchChatSpace &&
+          <ChatSpace
+            userName={props.userName}
+            roomId={roomId}
+            roomName={roomName}
+          />}
       </div>
+
+      <div className='context-menu' id='contextMenu'>
+        <ul>
+          <li id='editRoom' onClick={() => setViewEditWindow(true)}>ルームを編集</li>
+          <li>ルームを削除</li>
+        </ul>
+      </div>
+      {viewEditWindow &&
+        <EditRoom
+          roomId={roomId}
+          roomName={roomName}
+          setViewEditWindow={setViewEditWindow}
+          setRoomInfo={setRoomData}
+        />}
     </div>
   );
 }

--- a/frontend/src/css/block-room-list.css
+++ b/frontend/src/css/block-room-list.css
@@ -1,5 +1,6 @@
 .whole {
   display: flex;
+  position: relative;
 }
 
 .room-list-space {

--- a/frontend/src/css/button.css
+++ b/frontend/src/css/button.css
@@ -17,7 +17,7 @@
   border: 1px solid #55c4e9;
   border-radius: 5px;
   color: white;
-  font-size: 1rem;
+  font-size: 0.9rem;
   line-height: 1.5;
   transition: 0.5s;
   background-color: #55c4e9;
@@ -25,8 +25,19 @@
 
 .create-button {
   width: 10%;
-  margin-left: 1%;
-  margin-bottom: 10%;
+  padding: 0.5vmax;
+  border: 1px solid #55c4e9;
+  border-radius: 5px;
+  color: white;
+  font-size: 1rem;
+  line-height: 1.5;
+  transition: 0.5s;
+  background-color: #55c4e9;
+}
+
+.edit-button {
+  width: fit-content;
+  margin: 0 5px 5px 0;
   padding: 0.5vmax;
   border: 1px solid #55c4e9;
   border-radius: 5px;
@@ -39,16 +50,37 @@
 
 .register-button:hover,
 .create-room-button:hover,
-.create-button:hover {
+.create-button:hover,
+.edit-button:hover {
   border-color: #1e8db1;
   background-color: #1e8db1;
 }
 
 .register-button:disabled,
-.create-button:disabled {
+.create-button:disabled,
+.edit-button:disabled {
   color: white;
   border-color: #c1eaf8;
   background-color: #c1eaf8;
+}
+
+.cancel-button {
+  width: fit-content;
+  margin: 0 5px 5px 0;
+  padding: 0.5vmax;
+  border: 1px solid #55c4e9;
+  border-radius: 5px;
+  color: #55c4e9;
+  font-size: 1rem;
+  line-height: 1.5;
+  transition: 0.5s;
+  background-color: white;
+}
+
+.cancel-button:hover {
+  color: #1e8db1;
+  border-color: #1e8db1;
+  background-color: #DDDDDD;
 }
 
 .send-message-button {
@@ -68,7 +100,25 @@
   background-color: #0034d1;
 }
 
-.send-message-button:disabled{
+.send-message-button:disabled {
   border-color: #99b3ff;
   background-color: #99b3ff;
+}
+
+.close-button {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  top: 5px;
+  right: 5px;
+  font-weight: bold;
+  border: 2px solid #333;
+  border-radius: 50%;
+  background-color: #fff;
+  transition: 0.5s;
+}
+
+.close-button:hover {
+  background-color: #333;
+  color: #fff;
 }

--- a/frontend/src/css/context-menu.css
+++ b/frontend/src/css/context-menu.css
@@ -1,0 +1,21 @@
+.context-menu {
+  position: fixed;
+  width: 200px;
+  padding: 5px 0;
+  left: 0px;
+  top: 0px;
+  display: none;
+  border: 1px solid #000;
+  border-radius: 5px;
+  background-color: #fff;
+}
+
+.context-menu li {
+  padding-left: 10%;
+  list-style: none;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background-color: antiquewhite;
+}

--- a/frontend/src/css/modal-window.css
+++ b/frontend/src/css/modal-window.css
@@ -1,0 +1,27 @@
+.modal-back {
+  position: absolute;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(128, 128, 128, 0.361);
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  width: 45%;
+  height: 50vh;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  border-radius: 5px;
+  background-color: whitesmoke;
+}
+
+.modal-content-button{
+  display: flex;
+  margin-top: auto;
+  margin-left: auto;
+}

--- a/frontend/src/css/text-box.css
+++ b/frontend/src/css/text-box.css
@@ -33,8 +33,27 @@
   transition: 0.5s;
 }
 
+.input-edited-room-name {
+  text-align: center;
+}
+
+.input-edited-room-name input {
+  width: 50%;
+  margin-top: 1%;
+  margin-left: 3%;
+  padding: 0.5vmax;
+  border: 1px solid #27acd9;
+  border-radius: 5px;
+  resize: both;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5;
+  transition: 0.5s;
+}
+
 .input-user-name input:focus,
-.input-room-name input:focus {
+.input-room-name input:focus,
+.input-edited-room-name input:focus {
   outline: none;
   box-shadow: 0 0 5px 1px #27acd9;
 }

--- a/frontend/src/css/text.css
+++ b/frontend/src/css/text.css
@@ -37,3 +37,14 @@
   font-size: 0.7rem;
   line-height: 1.5;
 }
+
+.edit-room-name-text {
+  width: 95%;
+  margin: 35px auto 10px;
+  padding: 0.5%;
+  border-bottom: 2px solid #DDDDDD;
+  font-size: 1.3rem;
+  font-weight: bold;
+  text-align: center;
+  background-color: whitesmoke;
+}


### PR DESCRIPTION
### **レビュー希望納期**
2023/03/14

### **Issue**
既存のルームの名前を編集する。

### **対応内容**
右クリックメニューの「ルームを編集」をクリック時、モーダルウィンドウを表示させる。
ウィンドウの内容は以下の通りである。
- 「ルーム名を変更します」というテキスト
- 「ルーム名」というテキスト
- テキストボックス（編集するルーム名が入力されている状態）
- 「変更」「キャンセル」「閉じる（×）」ボタン

ウィンドウ、テキスト、テキストボックス、ボタンのデザインも新たに追加した。

### **動作確認**
右クリックメニューの「ルームを編集」をクリック時、モーダルウィンドウが表示される。
表示されたウィンドウのテキストボックスには、編集するルーム名があらかじめ入力されている。
ルーム名を編集して変更ボタンを押下すると、ルーム一覧にあるルーム名が更新（編集後のルーム名が表示）される。
閉じる、キャンセルボタンのどちらかを押下するとウィンドウが閉じる。

### **レビューポイント**
なし

### **備考**
ルームに入室した（チャットが表示されている）状態で、そのルームを編集するとチャット画面上部に表示されているルーム名は更新されない。

44212d2dc2265fc592425a5bc4e8dde683dd24bb